### PR TITLE
fix bug 1456956 - trigger off of processed crashes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,33 +1,23 @@
 Submitter
 =========
 
-AWS Lambda function that reacts to S3 object save events and submits a
-specified percentage of the accepted ones to another environment.
+AWS Lambda function that reacts to S3 object save events for processed crash
+files and submits a specified percentage to another environment.
 
 
 Details
 =======
 
-Raw crash files have keys like this::
+Processed crash files have keys like this::
 
-  v2/raw_crash/000/20180313/00007bd0-2d1c-4865-af09-80bc00180313
+  v1/processed_crash/00007bd0-2d1c-4865-af09-80bc00180313
 
 
-The accept/defer annotation is the 7th-to-last character of the key::
-
-  v2/raw_crash/000/20180313/00007bd0-2d1c-4865-af09-80bc00180313
-                                                         ^
-
-* ``0`` - defer
-* ``1`` - accept
-* any other values are junk and ignored
-
-If this file is a raw crash and it was accepted for processing, then the
-submitter will "roll a die" to decide whether to submit to a specified
+The submitter will "roll a die" to decide whether to submit to a specified
 environment.
 
-If so, it'll pull all the data from S3, package it up, and HTTP POST it to the
-collector of the specified environment.
+If so, it'll pull all the raw crash data from S3, package it up, and HTTP POST
+it to the collector of the specified environment.
 
 
 Quickstart
@@ -81,7 +71,7 @@ Quickstart
 
    .. code-block:: shell
 
-      $ ./bin/generate_event.py --key v2/raw_crash/000/20180313/00007bd0-2d1c-4865-af09-80bc00180313 > event.json
+      $ ./bin/generate_event.py --key v2/processed_crash/00007bd0-2d1c-4865-af09-80bc00180313 > event.json
       $ cat event.json | ./bin/run_invoke.sh
       <invoke output>
 

--- a/bin/integration_test.sh
+++ b/bin/integration_test.sh
@@ -47,9 +47,9 @@ docker-compose up -d antenna
 ./bin/wait.sh localhost 8888
 
 # Get a crash id from the fakecrashdata directory
-# CRASHID=$(find fakecrashdata/ -type f | grep raw_crash | awk -F / '{print $6}')
+# CRASHID=$(find fakecrashdata/ -type f | grep processed_crash | awk -F / '{print $6}')
 CRASHID="11107bd0-2d1c-4865-af09-80bc00180313"
-CRASHKEY="v2/raw_crash/${CRASHID:0:3}/20${CRASHID:30:6}/${CRASHID}"
+CRASHKEY="v1/processed_crash/${CRASHID}"
 
 # Copy source crash data into S3 source bucket
 docker-compose run -u "${HOSTUSER}" test ./bin/aws_s3.sh sync "${SOURCEDIR}" "${SOURCEBUCKET}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,11 +58,7 @@ class LambdaContext:
 class SubmitterClient:
     """Class for submitter in the AWS lambda environment"""
     def crash_id_to_key(self, crash_id):
-        return 'v2/raw_crash/{entropy}/{date}/{crashid}'.format(
-            entropy=crash_id[0:3],
-            date='20' + crash_id[-6:],
-            crashid=crash_id
-        )
+        return 'v1/processed_crash/%s' % crash_id
 
     def build_crash_save_events(self, keys):
         if isinstance(keys, str):


### PR DESCRIPTION
This redoes the submitter to trigger off of processed crashes instead of
raw crashes. The submitter's mission is to submit some percent of the
crashes that *were processed* to another environment. Given that, it
makes more sense to trigger off of saved processed crashes and not
trigger off of saved raw crashes and check the throttle instruction.