### PR TITLE
bug 1568977: change to trigger on v2/raw_crash/

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Submitter
 =========
 
-AWS Lambda function that reacts to S3 object save events for processed crash
+AWS Lambda function that reacts to S3 object save events for raw crash
 files and submits a specified percentage to another environment.
 
 * Free software: Mozilla Public License version 2.0
@@ -13,9 +13,9 @@ files and submits a specified percentage to another environment.
 Details
 =======
 
-Processed crash files have keys like this::
+Raw crash files have keys like this::
 
-  v1/processed_crash/00007bd0-2d1c-4865-af09-80bc00180313
+  v2/raw_crash/000/20170413/00007bd0-2d1c-4865-af09-80bc00170413
 
 
 The submitter will "roll a die" to decide whether to submit to a specified
@@ -76,7 +76,7 @@ Quickstart
 
    .. code-block:: shell
 
-      $ ./bin/generate_event.py --key v1/processed_crash/00007bd0-2d1c-4865-af09-80bc00180313 > event.json
+      $ ./bin/generate_event.py --key v2/raw_crash/000/20170413/00007bd0-2d1c-4865-af09-80bc00170413 > event.json
       $ cat event.json | ./bin/run_invoke.sh
       <invoke output>
 

--- a/bin/integration_test.sh
+++ b/bin/integration_test.sh
@@ -47,9 +47,9 @@ docker-compose up -d antenna
 ./bin/wait.sh localhost 8888
 
 # Get a crash id from the fakecrashdata directory
-# CRASHID=$(find fakecrashdata/ -type f | grep processed_crash | awk -F / '{print $6}')
+# CRASHID=$(find fakecrashdata/ -type f | grep raw_crash | awk -F / '{print $6}')
 CRASHID="11107bd0-2d1c-4865-af09-80bc00180313"
-CRASHKEY="v1/processed_crash/${CRASHID}"
+CRASHKEY="v2/raw_crash/111/20180313/${CRASHID}"
 
 # Copy source crash data into S3 source bucket
 docker-compose run -u "${HOSTUSER}" test ./bin/aws_s3.sh sync "${SOURCEDIR}" "${SOURCEBUCKET}"

--- a/src/submitter.py
+++ b/src/submitter.py
@@ -147,10 +147,10 @@ def extract_crash_id_from_record(record):
     try:
         key = record["s3"]["object"]["key"]
         logger.info("looking at key: %s", key)
-        if not key.startswith("v1/processed_crash/"):
-            logger.debug("%s: not a processed crash--ignoring", repr(key))
+        if not key.startswith("v2/raw_crash/"):
+            logger.debug("%s: not a raw crash--ignoring", repr(key))
             return None
-        crash_id = key.rsplit("/", 1)[-1]
+        crash_id = key.rsplit("/", 3)[-1]
         if not is_crash_id(crash_id):
             logger.debug("%s: not a crash id--ignoring", repr(key))
             return None
@@ -329,7 +329,7 @@ def handler(event, context):
         # Extract bucket name for debugging
         bucket = record["s3"]["bucket"]["name"]
 
-        # Extract crash id--if it's not a processed crash object, skip it.
+        # Extract crash id--if it's not a raw crash object, skip it.
         crash_id = extract_crash_id_from_record(record)
         if crash_id is None:
             continue

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,7 @@ class SubmitterClient:
     """Class for submitter in the AWS lambda environment"""
 
     def crash_id_to_key(self, crash_id):
-        return "v1/processed_crash/%s" % crash_id
+        return "v2/raw_crash/%s/%s/%s" % (crash_id[0:3], crash_id[-6:], crash_id)
 
     def build_crash_save_events(self, keys):
         if isinstance(keys, str):

--- a/tests/test_submitter.py
+++ b/tests/test_submitter.py
@@ -218,15 +218,15 @@ def test_env_tag_added_to_statds_incr(client, capsys, fakes3, mock_collector):
 @pytest.mark.parametrize(
     "data, expected",
     [
-        # Processed crash file
+        # Raw crash file
         (
-            "v1/processed_crash/de1bb258-cbbf-4589-a673-34f800160918",
+            "v2/raw_crash/de1/20160918/de1bb258-cbbf-4589-a673-34f800160918",
             "de1bb258-cbbf-4589-a673-34f800160918",
         ),
         # Other files that get saved in the same bucket
         ("v1/dump_names/de1bb258-cbbf-4589-a673-34f800160918", None),
         ("v1/upload_file_minidump/de1bb258-cbbf-4589-a673-34f800160918", None),
-        ("v2/raw_crash/de1/20160918/de1bb258-cbbf-4589-a673-34f800160918", None),
+        ("v1/processed_crash/de1bb258-cbbf-4589-a673-34f800160918", None),
         # Test-like files we might have pushed places to make sure things are working
         ("v1/processed_crash/test", None),
         ("foo/bar/test", None),


### PR DESCRIPTION
This changes the stage submitter lambda job to trigger on `v2/raw_crash/` rather than `v1/processed_crash/`. Since we're no longer using Pigeon, we can switch the stage submitter over and then stage won't get swamped when we reprocess crash reports in prod.