### PR TITLE
bug 1609739: emit metrics via logging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      # base image for primary container
-      - image: circleci/python:3.6.1
-
+      - image: mozilla/cidockerbases:docker-latest
     working_directory: ~/socorrosubmitter
 
     steps:
@@ -34,8 +32,11 @@ jobs:
 
       - run:
           name: Build libs
-          command: bin/run_build.sh
+          command: make build-libs
 
       - run:
-          name: Run tests
-          command: bin/run_circle.sh
+          name: Run linting and tests
+          command: |
+            # Run linting and tests without volume mounting because that
+            # doesn't work in CircleCI
+            ./bin/run_circle.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,10 +31,6 @@ jobs:
           command: make build-containers
 
       - run:
-          name: Build libs
-          command: make build-libs
-
-      - run:
           name: Run linting and tests
           command: |
             # Run linting and tests without volume mounting because that

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[Makefile]
+indent_style = tab
+
+[*.json]
+indent_size = 2
+
+[*.yml]
+indent_size = 2
+
+[*.py]
+max_line_length = 88

--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,7 @@ Scripts
 * ``bin/generate_event.py``: Generates a sample AWS S3 event.
 
 * ``bin/run_invoke.sh``: Invokes the submitter function in a AWS Lambda Python
-  3.6 runtime environment.
+  3.8 runtime environment.
 
 * ``bin/integration_test.sh``: Runs an integration test.
 

--- a/bin/run_circle.sh
+++ b/bin/run_circle.sh
@@ -19,11 +19,11 @@ docker run \
     --rm \
     --workdir=/app \
     --env-file=docker/lambda.env \
-    socorrosubmitter_test bin/run_lint.sh
+    local/socorrosubmitter_test bin/run_lint.sh
 
 # Run test
 docker run \
     --rm \
     --workdir=/app \
     --env-file=docker/lambda.env \
-    socorrosubmitter_test pytest
+    local/socorrosubmitter_test pytest

--- a/bin/run_invoke.sh
+++ b/bin/run_invoke.sh
@@ -4,11 +4,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# Invokes the submitter lambda function in a python3.6 lambda runtime
-# environment. Pass an event in via stdin.
+# Invokes the submitter lambda function in a lambda runtime environment. Pass
+# an event in via stdin.
 #
-# This turns around and uses lambci/lambda:python3.6, so any of those
-# args will work, too.
+# This turns around and uses lambci/lambda:python3.8, so any of those args will
+# work, too.
 #
 # https://github.com/lambci/docker-lambda#example
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     build:
       context: .
       dockerfile: docker/test/Dockerfile
+    image: local/socorrosubmitter_test
     env_file: docker/lambda.env
     volumes:
       - .:/app

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.8@sha256:1a126607adde46a706e76357c910f36b9f5529fb575d4d86a639a4997daceba7
 
 WORKDIR /app/
 RUN groupadd --gid 1001 app && useradd -g app --uid 1001 --shell /usr/sbin/nologin app

--- a/src/submitter.py
+++ b/src/submitter.py
@@ -96,9 +96,7 @@ def setup_logging(config):
             }
         },
         "root": {"handlers": ["console"], "level": "WARNING"},
-        "loggers": {
-            LOGGER_NAME: {"propagate": False, "handlers": ["console"], "level": "INFO"}
-        },
+        "loggers": {LOGGER_NAME: {"handlers": ["console"], "level": "INFO"}},
     }
 
     logging.config.dictConfig(logging_config)
@@ -131,10 +129,15 @@ def statsd_incr(key, value=1, tags=None):
     else:
         tags = ""
 
-    print(
-        "MONITORING|%(timestamp)s|%(val)s|count|%(key)s|%(tags)s"
-        % {"timestamp": int(time.time()), "key": key, "val": value, "tags": tags}
-    )
+    # We pass the data in the message and in extra because mozlog will add
+    # extra fields to its JSON msg
+    msg = "MONITORING|%(timestamp)s|%(value)s|count|%(key)s|%(tags)s" % {
+        "timestamp": int(time.time()),
+        "key": key,
+        "value": value,
+        "tags": tags,
+    }
+    LOGGER.info(msg, extra={"key": key, "value": value, "tags": tags})
 
 
 CRASH_ID_RE = re.compile(

--- a/tests/test_submitter.py
+++ b/tests/test_submitter.py
@@ -2,12 +2,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import logging
+
 import pytest
 
 from submitter import CONFIG, extract_crash_id_from_record
 
 
-def test_basic(client, capsys, fakes3, mock_collector):
+def test_basic(client, caplog, fakes3, mock_collector):
     fakes3.create_bucket()
     fakes3.save_crash(
         raw_crash={
@@ -21,9 +23,11 @@ def test_basic(client, capsys, fakes3, mock_collector):
     crash_id = "de1bb258-cbbf-4589-a673-34f800160918"
     events = client.build_crash_save_events(client.crash_id_to_key(crash_id))
 
-    # Make sure it doesn't get throttled and invoke the Lambda function
-    with CONFIG.override(throttle=100):
-        assert client.run(events) is None
+    # Capture logs, make sure it doesn't get throttled, and invoke the Lambda
+    # function
+    with caplog.at_level(logging.INFO):
+        with CONFIG.override(throttle=100):
+            assert client.run(events) is None
 
     # Verify payload was submitted
     assert len(mock_collector.payloads) == 1
@@ -54,11 +58,10 @@ def test_basic(client, capsys, fakes3, mock_collector):
         "--01659896d5dc42cabd7f3d8a3dcdd3bb--\r\n"
     )
 
-    stdout, stderr = capsys.readouterr()
-    assert "|1|count|socorro.submitter.accept|" in stdout
+    assert "|1|count|socorro.submitter.accept|#env:test" in caplog.record_tuples[0][2]
 
 
-def test_multiple_dumps(client, capsys, fakes3, mock_collector):
+def test_multiple_dumps(client, caplog, fakes3, mock_collector):
     fakes3.create_bucket()
     fakes3.save_crash(
         raw_crash={
@@ -75,9 +78,11 @@ def test_multiple_dumps(client, capsys, fakes3, mock_collector):
     crash_id = "de1bb258-cbbf-4589-a673-34f800160918"
     events = client.build_crash_save_events(client.crash_id_to_key(crash_id))
 
-    # Make sure it doesn't get throttled and invoke the Lambda function
-    with CONFIG.override(throttle=100):
-        assert client.run(events) is None
+    # Capture logs, make sure it doesn't get throttled, and invoke the Lambda
+    # function
+    with caplog.at_level(logging.INFO):
+        with CONFIG.override(throttle=100):
+            assert client.run(events) is None
 
     # Verify payload was submitted
     assert len(mock_collector.payloads) == 1
@@ -114,8 +119,7 @@ def test_multiple_dumps(client, capsys, fakes3, mock_collector):
         "--01659896d5dc42cabd7f3d8a3dcdd3bb--\r\n"
     )
 
-    stdout, stderr = capsys.readouterr()
-    assert "|1|count|socorro.submitter.accept|" in stdout
+    assert "|1|count|socorro.submitter.accept|" in caplog.record_tuples[0][2]
 
 
 def test_non_s3_event_ignored(client, fakes3, mock_collector):
@@ -136,7 +140,7 @@ def test_non_put_event_ignored(client, fakes3, mock_collector):
     assert len(mock_collector.payloads) == 0
 
 
-def test_throttle_accepted(client, capsys, mocker, fakes3, mock_collector):
+def test_throttle_accepted(client, caplog, mocker, fakes3, mock_collector):
     always_20 = mocker.patch("random.randint")
     always_20.return_value = 20
 
@@ -153,17 +157,18 @@ def test_throttle_accepted(client, capsys, mocker, fakes3, mock_collector):
     crash_id = "de1bb258-cbbf-4589-a673-34f800160918"
     events = client.build_crash_save_events(client.crash_id_to_key(crash_id))
 
-    # Set throttle value above the mocked randint, so this should get submitted
-    with CONFIG.override(throttle=30):
-        assert client.run(events) is None
+    # Capture the log and set throttle value above the mocked randint--this should
+    # get submitted
+    with caplog.at_level(logging.INFO):
+        with CONFIG.override(throttle=30):
+            assert client.run(events) is None
 
     # Verify payload was submitted
     assert len(mock_collector.payloads) == 1
-    stdout, stderr = capsys.readouterr()
-    assert "|1|count|socorro.submitter.accept|" in stdout
+    assert "|1|count|socorro.submitter.accept|" in caplog.record_tuples[0][2]
 
 
-def test_throttle_skipped(client, capsys, mocker, fakes3, mock_collector):
+def test_throttle_skipped(client, caplog, mocker, fakes3, mock_collector):
     always_20 = mocker.patch("random.randint")
     always_20.return_value = 20
 
@@ -180,18 +185,19 @@ def test_throttle_skipped(client, capsys, mocker, fakes3, mock_collector):
     crash_id = "de1bb258-cbbf-4589-a673-34f800160918"
     events = client.build_crash_save_events(client.crash_id_to_key(crash_id))
 
-    # Set throttle value below the mocked randint, so this should get skipped
-    with CONFIG.override(throttle=10):
-        assert client.run(events) is None
+    # Capture the logs and set throttle value below the mocked randint--this
+    # should get skipped
+    with caplog.at_level(logging.INFO):
+        with CONFIG.override(throttle=10):
+            assert client.run(events) is None
 
     # Verify no payload was submitted
     assert len(mock_collector.payloads) == 0
 
-    stdout, stderr = capsys.readouterr()
-    assert "|1|count|socorro.submitter.throttled|" in stdout
+    assert "|1|count|socorro.submitter.throttled|" in caplog.record_tuples[1][2]
 
 
-def test_env_tag_added_to_statds_incr(client, capsys, fakes3, mock_collector):
+def test_env_tag_added_to_statds_incr(client, caplog, fakes3, mock_collector):
     fakes3.create_bucket()
     fakes3.save_crash(
         raw_crash={
@@ -202,17 +208,17 @@ def test_env_tag_added_to_statds_incr(client, capsys, fakes3, mock_collector):
         dumps={"upload_file_minidump": "abcdef"},
     )
 
-    with CONFIG.override(env_name="stage", throttle=100):
-        crash_id = "de1bb258-cbbf-4589-a673-34f800160918"
-        #                                        ^ accept
-        events = client.build_crash_save_events(client.crash_id_to_key(crash_id))
-        assert client.run(events) is None
+    with caplog.at_level(logging.INFO):
+        with CONFIG.override(env_name="stage", throttle=100):
+            crash_id = "de1bb258-cbbf-4589-a673-34f800160918"
+            #                                        ^ accept
+            events = client.build_crash_save_events(client.crash_id_to_key(crash_id))
+            assert client.run(events) is None
 
-        # Verify payload was submitted
-        assert len(mock_collector.payloads) == 1
+    # Verify payload was submitted
+    assert len(mock_collector.payloads) == 1
 
-        stdout, stderr = capsys.readouterr()
-        assert "|1|count|socorro.submitter.accept|#env:stage\n" in stdout
+    assert "|1|count|socorro.submitter.accept|#env:stage" in caplog.record_tuples[0][2]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
We're not using cloudwatch anymore, so we need to emit the metrics in a
different way. This emits them via logging which we can pick up with
stackdriver and I can query them in BigQuery.