### PR TITLE
bug 1605140: support annotations as JSON

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ lintfix: .container-test  ## | Reformat code.
 
 .PHONY: test
 test: build  ## | Run tests.
-	${DC} run test py.test
+	${DC} run test pytest -vv
 
 .PHONY: testshell
 testshell: build  ## | Open shell in test container.


### PR DESCRIPTION
This adds support for submitting crash reports where the original
payload came in with crash annotations encoded as JSON in the "extra"
form data field.