### PR TITLE
bug 1680067: support payload_compressed

### DIFF
--- a/src/submitter.py
+++ b/src/submitter.py
@@ -6,6 +6,7 @@
 
 import contextlib
 from email.header import Header
+import gzip
 import io
 import json
 import logging
@@ -353,6 +354,16 @@ def multipart_encode(raw_crash, dumps):
         "Content-Type": "multipart/form-data; boundary=%s" % boundary,
         "Content-Length": str(len(output)),
     }
+
+    # Compress if it we need to
+    if raw_crash.get("payload_compressed", "") == "1":
+        bio = io.BytesIO()
+        g = gzip.GzipFile(fileobj=bio, mode="w")
+        g.write(output)
+        g.close()
+        output = bio.getbuffer()
+        headers["Content-Length"] = str(len(output))
+        headers["Content-Encoding"] = "gzip"
 
     return output, headers
 


### PR DESCRIPTION
This fixes the submitter to support `payload_compressed`. When the raw
crash has this field set to 1, then it was originally sent compressed.
Now the submitter will compress it and send it whereas previously it
would send it uncompressed.