### PR TITLE
bug 1687987: support version 2 raw crash

### DIFF
--- a/tests/test_submitter.py
+++ b/tests/test_submitter.py
@@ -8,16 +8,102 @@ import random
 
 import pytest
 
-from submitter import CONFIG, extract_crash_id_from_record
+from submitter import (
+    CONFIG,
+    extract_crash_id_from_record,
+    get_payload_type,
+    get_payload_compressed,
+    remove_collector_keys,
+)
+
+
+@pytest.mark.parametrize(
+    "raw_crash, expected",
+    [
+        ({}, "unknown"),
+        ({"payload": "json"}, "json"),
+        ({"metadata": {"payload": "json"}}, "json"),
+    ],
+)
+def test_get_payload_type(raw_crash, expected):
+    assert get_payload_type(raw_crash) == expected
+
+
+@pytest.mark.parametrize(
+    "raw_crash, expected",
+    [
+        ({}, "0"),
+        ({"payload_compressed": "1"}, "1"),
+        ({"metadata": {"payload_compressed": "1"}}, "1"),
+    ],
+)
+def test_get_payload_compressed(raw_crash, expected):
+    assert get_payload_compressed(raw_crash) == expected
+
+
+@pytest.mark.parametrize(
+    "raw_crash, expected",
+    [
+        ({}, {}),
+        # Version 1
+        (
+            {
+                "Product": "Firefox",
+                "Version": "60.0",
+                "collector_notes": [],
+                "dump_checksums": {},
+                "payload_compressed": "0",
+                "payload": "multipart",
+                "uuid": "de1bb258-cbbf-4589-a673-34f800160918",
+                "submitted_timestamp": "2022-09-14T15:45:55.222222",
+            },
+            {
+                "Product": "Firefox",
+                "Version": "60.0",
+                "uuid": "de1bb258-cbbf-4589-a673-34f800160918",
+            },
+        ),
+        # Version 2
+        (
+            {
+                "Product": "Firefox",
+                "Version": "60.0",
+                "metadata": {
+                    "collector_notes": [],
+                    "dump_checksums": {},
+                    "payload_compressed": "0",
+                    "payload": "multipart",
+                },
+                "version": 2,
+                "uuid": "de1bb258-cbbf-4589-a673-34f800160918",
+                "submitted_timestamp": "2022-09-14T15:45:55.222222",
+            },
+            {
+                "Product": "Firefox",
+                "Version": "60.0",
+                "uuid": "de1bb258-cbbf-4589-a673-34f800160918",
+            },
+        ),
+    ],
+)
+def test_remove_collector_keys(raw_crash, expected):
+    assert remove_collector_keys(raw_crash) == expected
 
 
 def test_basic(client, caplog, fakes3, mock_collector):
     fakes3.create_bucket()
     fakes3.save_crash(
         raw_crash={
-            "uuid": "de1bb258-cbbf-4589-a673-34f800160918",
             "Product": "Firefox",
+            "uuid": "de1bb258-cbbf-4589-a673-34f800160918",
             "Version": "60.0",
+            "metadata": {
+                "collector_notes": [],
+                "dump_checksums": {},
+                "payload_compressed": "0",
+                "payload": "multipart",
+            },
+            "version": 2,
         },
         dumps={"upload_file_minidump": "abcdef"},
     )
@@ -71,6 +157,52 @@ def test_annotations_as_json(client, caplog, fakes3, mock_collector):
             "Product": "Firefox",
             "Version": "60.0",
             "payload": "json",
+        },
+        dumps={"upload_file_minidump": "abcdef"},
+    )
+
+    crash_id = "de1bb258-cbbf-4589-a673-34f800160918"
+    events = client.build_crash_save_events(client.crash_id_to_key(crash_id))
+
+    # Capture logs, make sure it doesn't get throttled, and invoke the Lambda
+    # function
+    with caplog.at_level(logging.INFO):
+        with CONFIG.override(throttle=100):
+            assert client.run(events) is None
+
+    # Verify payload was submitted
+    assert len(mock_collector.payloads) == 1
+    post_payload = mock_collector.payloads[0].text
+
+    # Who doesn't like reading raw multipart/form-data? Woo hoo!
+    assert (
+        post_payload == "--01659896d5dc42cabd7f3d8a3dcdd3bb\r\n"
+        'Content-Disposition: form-data; name="extra"\r\n'
+        "Content-Type: application/json\r\n"
+        "\r\n"
+        '{"Product":"Firefox","Version":"60.0","uuid":"de1bb258-cbbf-4589-a673-34f800160918"}\r\n'
+        "--01659896d5dc42cabd7f3d8a3dcdd3bb\r\n"
+        'Content-Disposition: form-data; name="upload_file_minidump"; filename="file.dump"\r\n'
+        "Content-Type: application/octet-stream\r\n"
+        "\r\n"
+        "abcdef\r\n"
+        "--01659896d5dc42cabd7f3d8a3dcdd3bb--\r\n"
+    )
+
+    assert "|1|count|socorro.submitter.accept|#env:test" in caplog.record_tuples[0][2]
+
+
+def test_version_2_annotations_as_json(client, caplog, fakes3, mock_collector):
+    fakes3.create_bucket()
+    fakes3.save_crash(
+        raw_crash={
+            "uuid": "de1bb258-cbbf-4589-a673-34f800160918",
+            "Product": "Firefox",
+            "Version": "60.0",
+            "metadata": {
+                "payload": "json",
+            },
+            "version": 2,
         },
         dumps={"upload_file_minidump": "abcdef"},
     )
@@ -224,6 +356,68 @@ def test_multiple_dumps(client, caplog, fakes3, mock_collector):
     )
 
     assert "|1|count|socorro.submitter.accept|" in caplog.record_tuples[0][2]
+
+
+def test_version_2_compressed(client, caplog, fakes3, mock_collector):
+    fakes3.create_bucket()
+    fakes3.save_crash(
+        raw_crash={
+            "uuid": "de1bb258-cbbf-4589-a673-34f800160918",
+            "Product": "Firefox",
+            "Version": "60.0",
+            "metadata": {
+                "payload_compressed": "1",
+            },
+            "version": 2,
+        },
+        dumps={"upload_file_minidump": "abcdef"},
+    )
+
+    crash_id = "de1bb258-cbbf-4589-a673-34f800160918"
+    events = client.build_crash_save_events(client.crash_id_to_key(crash_id))
+
+    # Capture logs, make sure it doesn't get throttled, and invoke the Lambda
+    # function
+    with caplog.at_level(logging.INFO):
+        with CONFIG.override(throttle=100):
+            assert client.run(events) is None
+
+    # Verify payload was submitted
+    assert len(mock_collector.payloads) == 1
+    req = mock_collector.payloads[0]
+    print(repr(req))
+
+    # Assert the header
+    assert req.headers["Content-Encoding"] == "gzip"
+
+    # Assert it was accepted
+    assert "|1|count|socorro.submitter.accept|#env:test" in caplog.record_tuples[0][2]
+
+    # Assert the length and payload are correct and payload is compressed
+    post_payload = req.body
+    assert len(post_payload) == int(req.headers["Content-Length"])
+
+    unzipped_payload = gzip.decompress(post_payload)
+    assert (
+        unzipped_payload == b"--01659896d5dc42cabd7f3d8a3dcdd3bb\r\n"
+        b'Content-Disposition: form-data; name="Product"\r\n'
+        b"Content-Type: text/plain; charset=utf-8\r\n\r\n"
+        b"Firefox\r\n"
+        b"--01659896d5dc42cabd7f3d8a3dcdd3bb\r\n"
+        b'Content-Disposition: form-data; name="Version"\r\n'
+        b"Content-Type: text/plain; charset=utf-8\r\n\r\n"
+        b"60.0\r\n"
+        b"--01659896d5dc42cabd7f3d8a3dcdd3bb\r\n"
+        b'Content-Disposition: form-data; name="uuid"\r\n'
+        b"Content-Type: text/plain; charset=utf-8\r\n\r\n"
+        b"de1bb258-cbbf-4589-a673-34f800160918\r\n"
+        b"--01659896d5dc42cabd7f3d8a3dcdd3bb\r\n"
+        b'Content-Disposition: form-data; name="upload_file_minidump"; '
+        b'filename="file.dump"\r\n'
+        b"Content-Type: application/octet-stream\r\n\r\n"
+        b"abcdef\r\n"
+        b"--01659896d5dc42cabd7f3d8a3dcdd3bb--\r\n"
+    )
 
 
 def test_non_s3_event_ignored(client, fakes3, mock_collector):


### PR DESCRIPTION
We're adjusting the structure of the raw crash so that collector-generated fields are primarily in "metadata". That makes it easier for a lot of things including the submitter since it allows us to add new fields to the collector without having to do a followup fix to the submitter to remove the keys from the crash report before submitting to stage.

This also adds a bunch of tests.